### PR TITLE
Decode error AND Add catalan language to LANGUAGE_MAPPING

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,7 @@ Available languages
 -------------------
 
 * Arabic
+* Catalan
 * Danish
 * Dutch
 * English

--- a/stop_words/__init__.py
+++ b/stop_words/__init__.py
@@ -7,6 +7,7 @@ STOP_WORDS_CACHE = {}
 
 LANGUAGE_MAPPING = {
     'ar': 'arabic',
+    'ca': 'catalan',
     'da': 'danish',
     'nl': 'dutch',
     'en': 'english',

--- a/stop_words/__init__.py
+++ b/stop_words/__init__.py
@@ -58,7 +58,7 @@ def get_stop_words(language):
     try:
         language_filename = '{0}{1}.txt'.format(STOP_WORDS_DIR, language)
         with open(language_filename, 'rb') as language_file:
-            stop_words = [line.strip().decode('utf-8')
+            stop_words = [line.decode('utf-8').strip()
                           for line in language_file.readlines()]
     except IOError:
         raise StopWordError(


### PR DESCRIPTION
**1. Add catalan language to LANGUAGE_MAPPING.**
     I previously I added the file with stop words in project "stop-words"

**2. Decode error**

```
stop_words = [line.strip().decode('utf-8')
             for line in language_file.readlines()]
```

Strip() return a copy of the string with leading and trailing whitespace characters removed.
But if the string contains non-ascii characters, Strip() causes a UnicodeDecodeError error
(eg UnicodeDecodeError: 'utf8' codec can not decode byte 0xc3 in position 34: unexpected end of data).

The workaround is to reorder the call:

```
stop_words = [line.decode('utf-8').strip()
             for line in language_file.readlines()]
```
