### PR TITLE
Enforces packaging of eggs into folders.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     author_email='alireza.savand@gmail.com',
     url='https://github.com/Alir3z4/python-stop-words',
     packages=find_packages(),
+    zip_safe=False,
     package_data={
         'stop_words': [
             'stop-words/*.txt',


### PR DESCRIPTION
We had an error in our CI pipeline where a package build would fail since the .egg of stop-words is downloaded as a zip. 

This leads to the following error where the initializer tries to open a directory when it is actually a zip archive.

``Not a directory: '/opt/project/.eggs/stop_words-2015.2.23.1-py3.6.egg/stop_words/stop-words/languages.json'``